### PR TITLE
18nguyenl/issue69

### DIFF
--- a/example/layout/index.html
+++ b/example/layout/index.html
@@ -26,6 +26,20 @@
                 <div class="square inline-flex color-cornsilk">1</div>
                 <div class="square inline-flex color-aqua">2</div>
                 <div class="square inline-flex color-lavendarblush">3</div>
+                <div class="square inline-flex color-cornsilk">1</div>
+                <div class="square inline-flex color-aqua">2</div>
+                <div class="square inline-flex color-lavendarblush">3</div>
+                <div class="square inline-flex color-cornsilk">1</div>
+                <div class="square inline-flex color-aqua">2</div>
+                <div class="square inline-flex color-lavendarblush">3</div>
+            </billboard-ticker>
+            <h3>Inline-flex Fill</h3>
+            <billboard-ticker>
+                <div class="inline-flex">
+                    <div class="square inline-flex color-cornsilk">1</div>
+                    <div class="square inline-flex color-aqua">2</div>
+                    <div class="square inline-flex color-lavendarblush">3</div>
+                </div>
             </billboard-ticker>
             <h3>Small</h3>
             <billboard-ticker id="webc-small">

--- a/src/clones/Clone.ts
+++ b/src/clones/Clone.ts
@@ -3,11 +3,13 @@ import Template from "./Template";
 import styles from "src/web/clone.module.css";
 
 export default class Clone {
+    private _template: Template;
     private _element: HTMLElement;
     private _width: number;
     private _height: number;
 
     constructor(template: Template) {
+        this._template = template;
         // Element-wrapper refers to a wrapper that allows for dimensional calculations
         // What you want to clone
         this._element = wrappedDiv(template.element.cloneNode(true));
@@ -18,6 +20,11 @@ export default class Clone {
 
         // Just add it in some far off corner so it's not visible yet.
         this.setPosition([-9999, -9999]);
+    }
+
+    measure() {
+        this._width = this._template.width;
+        this._height = this._template.height;
     }
 
     setPosition(position: [x: number, y: number]) {

--- a/src/clones/Clone.ts
+++ b/src/clones/Clone.ts
@@ -5,8 +5,6 @@ import styles from "src/web/clone.module.css";
 export default class Clone {
     private _template: Template;
     private _element: HTMLElement;
-    private _width: number;
-    private _height: number;
 
     constructor(template: Template) {
         this._template = template;
@@ -15,16 +13,8 @@ export default class Clone {
         this._element = wrappedDiv(template.element.cloneNode(true));
         this._element.classList.add(styles.clone);
 
-        this._width = template.width;
-        this._height = template.height;
-
         // Just add it in some far off corner so it's not visible yet.
         this.setPosition([-9999, -9999]);
-    }
-
-    measure() {
-        this._width = this._template.width;
-        this._height = this._template.height;
     }
 
     setPosition(position: [x: number, y: number]) {
@@ -53,11 +43,11 @@ export default class Clone {
     }
 
     get width(): number {
-        return this._width;
+        return this._template.width;
     }
 
     get height(): number {
-        return this._height;
+        return this._template.height;
     }
 
     set transformStyle(style: string) {

--- a/src/clones/Template.ts
+++ b/src/clones/Template.ts
@@ -6,6 +6,7 @@ export default class Template {
     private _original: Parameters<typeof wrappedDiv>[0];
 
     private _element: HTMLElement;
+    private _elementComputedStyles: CSSStyleDeclaration;
     private _width: number;
     private _height: number;
 
@@ -19,15 +20,22 @@ export default class Template {
         // Element represents the element to be repeated (the template if you will)
         this._element = wrappedDiv(this._original);
         this._element.classList.add(styles.template);
+        this._elementComputedStyles = window.getComputedStyle(this._element);
 
-        this._originalParent?.append(this._element);
-        this._width = this._element.offsetWidth;
-        this._height = this._element.offsetHeight;
-        this._element.remove();
+        this._width = 0;
+        this._height = 0;
+        this.measure();
 
         // recover the original after modification, unique hack...
         // what's happening is that the original became the this.element
         this._original = this._element.children;
+    }
+
+    measure() {
+        this._originalParent?.append(this._element);
+        this._width = parseFloat(this._elementComputedStyles.width);
+        this._height = parseFloat(this._elementComputedStyles.height);
+        this._element.remove();
     }
 
     get element() {

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -23,12 +23,18 @@ export default class Ticker {
             this._wrapperElement
         );
 
+        this._width = 0;
+        this._height = 0;
+
         // Billboard-ticker refers to what represents the entire Billboard-ticker itself
         this._element = document.createElement("div");
         this._element.classList.add(styles.tickerContainer);
 
-        this._width = parseFloat(this._wrapperComputedStyles.width);
-        this._height = parseFloat(this._wrapperComputedStyles.height);
+        if (!(this._wrapperElement instanceof Component)) {
+            this._wrapperElement.classList.add(styles.ticker);
+        }
+
+        this.measure();
     }
 
     get isRendered(): boolean {
@@ -62,7 +68,7 @@ export default class Ticker {
             this._height = parseFloat(this._wrapperComputedStyles.height);
         }
 
-        this._element.style.minHeight = `${this._height}px`;
+        this._element.style.height = `${this._height}px`;
     }
 
     set width(width: number) {
@@ -77,16 +83,17 @@ export default class Ticker {
             this._width = parseFloat(this._wrapperComputedStyles.width);
         }
 
-        this._element.style.minWidth = `${this._width}px`;
+        this._element.style.width = `${this._width}px`;
+    }
+
+    measure() {
+        this.width = parseFloat(this._wrapperComputedStyles.width);
+        this.height = parseFloat(this._wrapperComputedStyles.height);
     }
 
     reloadInitialTemplate() {
         if (!this._initialTemplate) {
             this._initialTemplate = new Template(this._wrapperElement.children);
-
-            // need to re-measure with a new initial template
-            this._height = parseFloat(this._wrapperComputedStyles.height);
-            this._width = parseFloat(this._wrapperComputedStyles.width);
         }
     }
 
@@ -96,8 +103,6 @@ export default class Ticker {
         }
 
         this.reloadInitialTemplate();
-        this.height = this._initialTemplate!.height;
-        this.width = this._initialTemplate!.width;
 
         this._wrapperElement.append(this._element);
     }

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -46,12 +46,12 @@ export default class Ticker {
         };
     }
 
-    set height(height: number) {
+    private set height(height: number) {
         this._height = height;
         this._element.style.height = `${this._height}px`;
     }
 
-    set width(width: number) {
+    private set width(width: number) {
         this._width = width;
         this._element.style.width = `${this._width}px`;
     }

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -29,12 +29,6 @@ export default class Ticker {
         // Billboard-ticker refers to what represents the entire Billboard-ticker itself
         this._element = document.createElement("div");
         this._element.classList.add(styles.tickerContainer);
-
-        if (!(this._wrapperElement instanceof Component)) {
-            this._wrapperElement.classList.add(styles.ticker);
-        }
-
-        this.measure();
     }
 
     get isRendered(): boolean {
@@ -52,52 +46,35 @@ export default class Ticker {
         };
     }
 
-    get height() {
-        return this._height;
-    }
-
     set height(height: number) {
         this._height = height;
-
-        // Override any height if there's one already defined in the parent
-        if (
-            this._wrapperElement.style.height ||
-            this._wrapperElement.style.maxHeight ||
-            this._wrapperElement.style.minHeight
-        ) {
-            this._height = parseFloat(this._wrapperComputedStyles.height);
-        }
-
         this._element.style.height = `${this._height}px`;
     }
 
     set width(width: number) {
         this._width = width;
-
-        // Override any width if there's one already defined in the parent
-        if (
-            this._wrapperElement.style.width ||
-            this._wrapperElement.style.maxWidth ||
-            this._wrapperElement.style.minWidth
-        ) {
-            this._width = parseFloat(this._wrapperComputedStyles.width);
-        }
-
         this._element.style.width = `${this._width}px`;
     }
 
     measure() {
-        this.width = parseFloat(this._wrapperComputedStyles.width);
-        this.height = parseFloat(this._wrapperComputedStyles.height);
+        if (!this.isRendered) {
+            this.width = parseFloat(this._wrapperComputedStyles.width);
+            this.height = parseFloat(this._wrapperComputedStyles.height);
+        } else {
+            throw "Measuring after Ticker rendered; You can only measure when the Ticker isn't rendered.";
+        }
     }
 
     reloadInitialTemplate() {
-        if (!this._initialTemplate) {
+        if (!this._initialTemplate && !this.isRendered) {
+            this.measure();
             this._initialTemplate = new Template(this._wrapperElement.children);
         }
     }
 
     load() {
+        // Stylize Containing Wrapper around the actual Ticker to
+        // ensure measurement and stuff doesn't leak out
         if (!(this._wrapperElement instanceof Component)) {
             this._wrapperElement.classList.add(styles.ticker);
         }
@@ -118,13 +95,8 @@ export default class Ticker {
         if (this._wrapperElement) {
             this._wrapperElement.classList.remove(styles.ticker);
         }
-        this._height = -1;
     }
 
-    // Add in a lil element but if it's a lil too big, then the ticker needs to resize
-    // [TODO] figure out responsiveness part
-    // might need to remove this part if someone already gave it a height that's less
-    // than any other height :/
     append(item: TickerItem) {
         item.appendTo(this._element);
     }

--- a/src/ticker/TickerSystem.ts
+++ b/src/ticker/TickerSystem.ts
@@ -73,16 +73,18 @@ export default class TickerSystem extends System {
             },
             { width: 0, height: 0 }
         );
+
         const repetition = {
             x:
-                Math.round(
+                Math.ceil(
                     this._ticker.dimensions.width / sequenceDimensions.width
                 ) + 2,
             y:
-                Math.round(
+                Math.ceil(
                     this._ticker.dimensions.height / sequenceDimensions.height
                 ) + 2,
         };
+
         const position: Position = [
             -sequenceDimensions.width,
             -sequenceDimensions.height,
@@ -141,8 +143,6 @@ export default class TickerSystem extends System {
         for (const item of this._tickerItemStore.allTickerItems) {
             item.remove();
         }
-
-        this._ticker.height = -1;
     }
 
     load() {

--- a/src/ticker/TickerSystem.ts
+++ b/src/ticker/TickerSystem.ts
@@ -88,48 +88,24 @@ export default class TickerSystem extends System {
             -sequenceDimensions.height,
         ];
 
-        const currSize = Array.from(this.allItems).length;
-        const deltaSize = repetition.x * repetition.y - 1 - currSize;
-        let tickerItems;
+        const tickerItems = initialSequence.concat(
+            this._tickerItemFactory.create(repetition.x * repetition.y - 1)
+        );
 
-        // if this is our first time laying stuff out
-        if (currSize === 1) {
-            tickerItems = initialSequence.concat(
-                this._tickerItemFactory.create(repetition.x * repetition.y - 1)
-            );
-        }
-        // otherwise, create more or less depending on the difference
-        else {
-            if (deltaSize > 0) {
-                tickerItems = this._tickerItemFactory.create(deltaSize);
-            } else if (deltaSize < 0) {
-                const allTickerItems = this.allItems;
-                let ti = allTickerItems.next();
-                for (let i = 0; i < Math.abs(deltaSize); i++) {
-                    if (!ti.done) {
-                        ti.value.remove();
-                        ti = allTickerItems.next();
-                    }
-                }
-            }
-        }
+        // iterate through clones and properly set the positions
+        let clonesIndex = 0;
+        let currItem = tickerItems[clonesIndex];
+        for (let i = 0; i < repetition.y; i++) {
+            for (let j = 0; j < repetition.x; j++) {
+                currItem = tickerItems[clonesIndex];
+                const { width: itemWidth, height: itemHeight } =
+                    currItem.dimensions;
 
-        if (tickerItems) {
-            // iterate through clones and properly set the positions
-            let clonesIndex = 0;
-            let currItem = tickerItems[clonesIndex];
-            for (let i = 0; i < repetition.y; i++) {
-                for (let j = 0; j < repetition.x; j++) {
-                    currItem = tickerItems[clonesIndex];
-                    const { width: itemWidth, height: itemHeight } =
-                        currItem.dimensions;
-
-                    currItem.position = [
-                        position[0] + j * itemWidth,
-                        position[1] + i * itemHeight,
-                    ];
-                    clonesIndex++;
-                }
+                currItem.position = [
+                    position[0] + j * itemWidth,
+                    position[1] + i * itemHeight,
+                ];
+                clonesIndex++;
             }
         }
     }

--- a/src/ticker/__test__/ticker.test.ts
+++ b/src/ticker/__test__/ticker.test.ts
@@ -11,6 +11,9 @@ describe("ticker", () => {
     it("should initialize the parent element when loaded", async () => {
         Basic.loadContent();
 
+        const initialHeight = await $(`#${Basic.ticker.id}`).getSize("height");
+        const initialWidth = await $(`#${Basic.ticker.id}`).getSize("width");
+
         const ticker = new Ticker(Basic.ticker);
         ticker.load();
 
@@ -23,12 +26,15 @@ describe("ticker", () => {
 
         const innerElement = await element.$("*");
         expect(innerElement).toHaveElementClass("billboard-ticker-container");
-
-        expect(ticker.height).not.toEqual(-1);
+        expect(await element.getSize("height")).toEqual(initialHeight);
+        expect(await element.getSize("width")).toEqual(initialWidth);
     });
 
     it("should return ticker to original when unloaded and remove state", async () => {
         Basic.loadContent();
+
+        const initialHeight = await $(`#${Basic.ticker.id}`).getSize("height");
+        const initialWidth = await $(`#${Basic.ticker.id}`).getSize("width");
 
         const ticker = new Ticker(Basic.ticker);
         ticker.load();
@@ -44,7 +50,8 @@ describe("ticker", () => {
         expect(
             await element.$(".billboard-ticker-container")
         ).not.toBeDisplayed();
-        expect(ticker.height).toEqual(-1);
+        expect(await element.getSize("height")).toEqual(initialHeight);
+        expect(await element.getSize("width")).toEqual(initialWidth);
     });
 
     it("can add a ticker item to the ticker", async () => {
@@ -94,14 +101,22 @@ describe("ticker", () => {
     it("should use parent element height if explicitly defined", async () => {
         Basic.loadContent();
 
+        async function getDimensions() {
+            const element = await $(Basic.ticker);
+
+            return {
+                width: await element.getSize("width"),
+                height: await element.getSize("height"),
+            };
+        }
+
         const ticker = new Ticker(Basic.ticker);
 
         Basic.ticker.style.height = "9px";
 
         ticker.load();
-        ticker.height = 1234;
 
-        expect(ticker.height).toEqual(9);
+        expect((await getDimensions()).height).toEqual(9);
 
         ticker.unload();
 
@@ -109,9 +124,8 @@ describe("ticker", () => {
         Basic.ticker.style.height = "200px";
 
         ticker.load();
-        ticker.height = 1234;
 
-        expect(ticker.height).toEqual(99);
+        expect((await getDimensions()).height).toEqual(99);
 
         ticker.unload();
 
@@ -119,8 +133,7 @@ describe("ticker", () => {
         Basic.ticker.style.height = "9px";
 
         ticker.load();
-        ticker.height = 1234;
 
-        expect(ticker.height).toEqual(999);
+        expect((await getDimensions()).height).toEqual(999);
     });
 });

--- a/src/web/clone.module.css
+++ b/src/web/clone.module.css
@@ -6,6 +6,4 @@
   position: absolute;
 
   will-change: transform;
-
-  display: inline-block;
 }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1,5 +1,4 @@
 billboard-ticker {
-  white-space: nowrap;
   overflow: hidden;
 
   display: block;

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -2,6 +2,4 @@ billboard-ticker {
   overflow: hidden;
 
   display: block;
-
-  border: 1px solid red;
 }

--- a/src/web/ticker.module.css
+++ b/src/web/ticker.module.css
@@ -2,8 +2,6 @@
   overflow: hidden;
 
   display: block;
-
-  border: 1px solid red;
 }
 
 .tickerContainer {

--- a/src/web/ticker.module.css
+++ b/src/web/ticker.module.css
@@ -1,5 +1,4 @@
 .ticker {
-  white-space: nowrap;
   overflow: hidden;
 
   display: block;
@@ -9,6 +8,5 @@
 
 .tickerContainer {
   position: relative;
-
   display: flow-root;
 }


### PR DESCRIPTION
Fixes #69 but with a major caveat: it doesn't actually fix anything besides the measurement of elements.

It turns out that trying to optimize resize introduced race conditions and a lot more complexity that would lag more than just tearing everything down and building it back up. I tried to make a system where you only add in the new elements as needed, but that also means you need to reverse, but not fully deconstruct the ticker to only add the new items. I could probably tinker this more appropriately, but I want to move onto more important things rather than straining this architecture more than it can handle. The main issue here is that DOM operations should've been separated and boxed out with some interface, not interwoven.