### PR TITLE
Test ClearContent clears everything

### DIFF
--- a/test/pages/base/Base.ts
+++ b/test/pages/base/Base.ts
@@ -2,6 +2,7 @@ import sharedCSS from "test/pages/shared/style.css?raw";
 
 export default class Base {
     protected htmlRoot: HTMLElement;
+    protected testContent: HTMLElement | undefined | null;
 
     constructor() {
         const currentRoot = document.getElementById("test-root");
@@ -9,14 +10,19 @@ export default class Base {
         else {
             this.htmlRoot = document.createElement("div");
             this.htmlRoot.id = "test-root";
-            this.htmlRoot.style.overflow = "scroll";
+            this.htmlRoot.style.position = "relative";
+            this.htmlRoot.style.zIndex = "-1";
 
             document.body.append(this.htmlRoot);
         }
     }
 
     loadHTML(htmlText: string) {
-        this.htmlRoot.insertAdjacentHTML("beforeend", htmlText);
+        const element = document.createElement("template");
+        element.innerHTML = htmlText;
+        this.testContent = element.content.firstElementChild as HTMLElement;
+
+        this.htmlRoot.insertAdjacentElement("beforeend", this.testContent);
     }
 
     loadCSS(cssText: string) {
@@ -32,7 +38,7 @@ export default class Base {
     }
 
     clearContent() {
-        this.htmlRoot.replaceChildren();
+        this.testContent?.remove();
 
         const styleElements = document.getElementsByTagName("style");
         for (const element of styleElements) {

--- a/test/pages/basic/Basic.ts
+++ b/test/pages/basic/Basic.ts
@@ -4,10 +4,10 @@ import basicCSS from "./style.css?raw";
 
 class Basic extends Base {
     get ticker() {
-        return document.getElementById("ticker")!;
+        return this.testContent;
     }
 
-    loadContent(): void {
+    loadContent() {
         super.loadContent(basicHTML, basicCSS);
     }
 }

--- a/test/pages/square/Square.ts
+++ b/test/pages/square/Square.ts
@@ -3,7 +3,7 @@ import squareHTML from "./index.html?raw";
 
 class Square extends Base {
     get square() {
-        return document.getElementById("square")!;
+        return this.testContent;
     }
 
     loadContent(): void {


### PR DESCRIPTION
Fixes #49

Note: Originally, I wanted to support the ability to create and select different HTML components on a page to set it up as PageObjects. Unfortunately, there would be some overhead to make that functionality work with the current architecture. This would be work for a future approach to testing, but for now, this is all that is necessary.