### PR TITLE
Make marquee visible for screen reader

### DIFF
--- a/.changeset/kind-carrots-glow.md
+++ b/.changeset/kind-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+"manawave": patch
+---
+
+Make marquee visible for accessibility customizability

--- a/package/src/dom/components/ticker.ts
+++ b/package/src/dom/components/ticker.ts
@@ -7,7 +7,6 @@ import styles from "../styles/ticker.module.css";
 export default class TickerComponent extends Component {
     constructor() {
         const element = document.createElement("div");
-        element.ariaHidden = "true";
         element.classList.add(styles.container);
 
         super(element);

--- a/package/src/ticker/context.ts
+++ b/package/src/ticker/context.ts
@@ -54,6 +54,15 @@ export default class Context {
             if (!(selected instanceof WebComponent))
                 selected.classList.add(styles.manawaveRoot);
 
+            // add a11y labeling
+            selected.role = "marquee";
+            if (
+                !selected.ariaLabel &&
+                !selected.hasAttribute("aria-labelledby")
+            ) {
+                selected.ariaLabel = "marquee";
+            }
+
             // WARNING IT HAS TO BE IN THIS SPECIFIC ORDER DO NOT CHANGE
             // basically, it first boxes the repeating items to be measured over time
             // then it removes them from the dom and places it inside a template to clone from


### PR DESCRIPTION
Fixes #190

Note: I need to write in the docs that if there's no vital information being conveyed by the marquee and the display is purely visual, I would encourage adding `aria-hidden` on the template instead of manawave choosing that for you. Sure there may be overwhelming repeated elements but better to have that information shown and controlled rather than none at all.